### PR TITLE
Prevent missing value (-9999) from breaking scale

### DIFF
--- a/src/shared.liquid
+++ b/src/shared.liquid
@@ -83,7 +83,9 @@
         return [Date.parse(d.validTime), d.primary];
       }))
       .filter(function(d) {
-        return d[0] >= daysAgo.getTime(); // Filter data within the range
+        // Filter out invalid sentinel values (NOAA uses -9999 for missing data)
+        // Also filter by date range
+        return d[0] >= daysAgo.getTime() && d[1] !== null && d[1] !== undefined && d[1] > -9000;
       });
 
     // Ensure the charted data is unique by removing duplicate entries based on validTime


### PR DESCRIPTION
<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e6e63d46-b2a2-4af0-8455-fc0622027bd0" />

The NWPS will send a value of `-9999` to indicate no data available. When this happens, our chart scaling is thrown off. This PR fixes the above behavior and shows the proper limits.