### PR TITLE
Shrink the transform function's results

### DIFF
--- a/src/shared.liquid
+++ b/src/shared.liquid
@@ -68,19 +68,19 @@
     var daysAgo = new Date(now.getTime() - daysToChart * 24 * 60 * 60 * 1000);
 
     observedData.data = observedData.data.filter(function(d) {
-      return Date.parse(d.validTime) <= now.getTime(); // Keep only entries earlier than or equal to now
+      return Date.parse(d.t) <= now.getTime(); // Keep only entries earlier than or equal to now
     });
 
     forecastData.data = forecastData.data.filter(function(d) {
-      return Date.parse(d.validTime) > now.getTime(); // Keep only entries later than now
+      return Date.parse(d.t) > now.getTime(); // Keep only entries later than now
     });
 
     var combinedData = observedData.data
       .map(function(d) {
-        return [Date.parse(d.validTime), d.primary];
+        return [Date.parse(d.t), d.p];
       })
       .concat(forecastData.data.map(function(d) {
-        return [Date.parse(d.validTime), d.primary];
+        return [Date.parse(d.t), d.p];
       }))
       .filter(function(d) {
         // Filter out invalid sentinel values (NOAA uses -9999 for missing data)

--- a/src/transform.js
+++ b/src/transform.js
@@ -61,12 +61,14 @@ function transform(input) {
         .filter(d =>
           d &&
           d.validTime &&
+          !d.validTime.includes(':15:00') &&
+          !d.validTime.includes(':45:00') &&
           d.primary != null &&
           d.primary > -9000 // NOAA missing-data sentinel
         )
         .map(d => ({
-          validTime: d.validTime,
-          primary: d.primary
+          t: d.validTime,
+          p: d.primary
         }))
     };
   }


### PR DESCRIPTION
This change reduces the amount of data coming from the transform function by cutting the data resolution in half and shortening the names of the returned properties.

When I tried to use the plugin for LID `PRLI1`, I was getting an error telling me the payload was too large. I wrote a test harness around the existing transform function and noticed that for this gauge, I was getting a total of 149,001 bytes of data at the time of my testing. The TRNML system was raising an error since the total data exceeded 100kb. I tweaked the transform function in my harness, and with a few small changes, I was able to cut the amount of data coming from the transform function from 149,001 bytes to 55,220 bytes, well under the 100kb limit. There may be further optimizations which would keep the data under the limit without reducing the data resolution, but halving the observed data resolution still maintains a level of resolution much higher than that of the forecast data, and I don't believe the reduction in resolution will be very noticeable in the final graph.